### PR TITLE
User can submit the same order to authorize.net twice and the Authorize.net Controller will process it twice

### DIFF
--- a/src/main/java/org/broadleafcommerce/vendor/authorizenet/web/controller/BroadleafAuthorizeNetController.java
+++ b/src/main/java/org/broadleafcommerce/vendor/authorizenet/web/controller/BroadleafAuthorizeNetController.java
@@ -22,6 +22,7 @@ import org.broadleafcommerce.core.checkout.service.exception.CheckoutException;
 import org.broadleafcommerce.core.checkout.service.workflow.CheckoutResponse;
 import org.broadleafcommerce.core.order.domain.NullOrderImpl;
 import org.broadleafcommerce.core.order.domain.Order;
+import org.broadleafcommerce.core.order.service.type.OrderStatus;
 import org.broadleafcommerce.core.payment.domain.PaymentInfo;
 import org.broadleafcommerce.core.payment.domain.PaymentResponseItem;
 import org.broadleafcommerce.core.payment.service.type.PaymentInfoType;
@@ -29,6 +30,7 @@ import org.broadleafcommerce.core.pricing.service.exception.PricingException;
 import org.broadleafcommerce.core.web.controller.checkout.BroadleafCheckoutController;
 import org.broadleafcommerce.core.web.order.CartState;
 import org.broadleafcommerce.vendor.authorizenet.service.payment.AuthorizeNetCheckoutService;
+import org.broadleafcommerce.vendor.authorizenet.service.payment.AuthorizeNetCheckoutServiceImpl;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -40,6 +42,8 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Enumeration;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import javax.annotation.Resource;
 import javax.servlet.http.HttpServletRequest;
@@ -60,6 +64,12 @@ public class BroadleafAuthorizeNetController extends BroadleafCheckoutController
 
     @Value("${authorizenet.confirm.url}")
     protected String authorizeNetConfirmUrl;
+    
+    /**
+     * Map of locks for given order ids. This lock map ensures that only a single request can handle a particular order
+     * at a time
+     */
+    protected ConcurrentMap<String, Object> lockMap = new ConcurrentHashMap<String, Object>();
 
     @Override
     public String checkout(HttpServletRequest request, HttpServletResponse response, Model model, RedirectAttributes redirectAttributes) {
@@ -93,46 +103,81 @@ public class BroadleafAuthorizeNetController extends BroadleafCheckoutController
     }
 
     public @ResponseBody String processAuthorizeNetAuthorizeAndDebit(HttpServletRequest request, HttpServletResponse response, Model model) throws NoSuchAlgorithmException, PricingException, InvalidKeyException, UnsupportedEncodingException, BroadleafAuthorizeNetException {
-    	LOG.debug("Authorize URL request - "+request.getRequestURL().toString());
-    	LOG.debug("Authorize Request Parameter Map (params: [" + requestParamToString(request) + "])");
-        Order order = authorizeNetCheckoutService.findCartForCustomer(request.getParameterMap());
-        if (order != null && !(order instanceof NullOrderImpl)) {
-            try {
-
-                CheckoutResponse checkoutResponse = authorizeNetCheckoutService.completeAuthorizeAndDebitCheckout(order, request.getParameterMap());
-
-                PaymentInfo authorizeNetPaymentInfo = null;
-                for (PaymentInfo paymentInfo : checkoutResponse.getPaymentResponse().getResponseItems().keySet()){
-                    if (PaymentInfoType.CREDIT_CARD.equals(paymentInfo.getType())){
-                        authorizeNetPaymentInfo = paymentInfo;
-                    }
-                }
-
-                PaymentResponseItem paymentResponseItem = checkoutResponse.getPaymentResponse().getResponseItems().get(authorizeNetPaymentInfo);
-                if (paymentResponseItem.getTransactionSuccess()){
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Transaction success for order " + checkoutResponse.getOrder().getOrderNumber());
-                        LOG.debug("Response for Authorize.net to relay to client: ");
-                        LOG.debug(authorizeNetCheckoutService.buildRelayResponse(authorizeNetConfirmUrl + "/" + checkoutResponse.getOrder().getOrderNumber()));
-                    }
-                    return authorizeNetCheckoutService.buildRelayResponse(authorizeNetConfirmUrl + "/" + checkoutResponse.getOrder().getOrderNumber());
-                }
-                
-            } catch (CheckoutException e) {
-                if (LOG.isErrorEnabled()) {
-                    LOG.error("Checkout Exception occurred processing Authorize.net relay response (params: [" + requestParamToString(request) + "])" + e);
-                }
-            }
-        } else {
-            if (LOG.isFatalEnabled()) {
-                LOG.fatal("The order could not be determined from the Authorize.net relay response (params: [" + requestParamToString(request) + "]). NOTE: The transaction may have completed successfully. Check your application keys and hash.");
-                throw new BroadleafAuthorizeNetException("Fatal Error has occured with in BroadleafAuthorizeNet");
-            }
-        }
+    	synchronized (getLock(request.getParameter(AuthorizeNetCheckoutServiceImpl.BLC_OID))) {
+    	    try {
+                LOG.debug("Authorize URL request - "+request.getRequestURL().toString());
+            	LOG.debug("Authorize Request Parameter Map (params: [" + requestParamToString(request) + "])");
+                Order order = authorizeNetCheckoutService.findCartForCustomer(request.getParameterMap());
+                if (order != null && !(order instanceof NullOrderImpl)) {
+                    try {
         
-        return authorizeNetCheckoutService.buildRelayResponse(authorizeNetErrorUrl);
+                        CheckoutResponse checkoutResponse = authorizeNetCheckoutService.completeAuthorizeAndDebitCheckout(order, request.getParameterMap());
+        
+                        PaymentInfo authorizeNetPaymentInfo = null;
+                        for (PaymentInfo paymentInfo : checkoutResponse.getPaymentResponse().getResponseItems().keySet()){
+                            if (PaymentInfoType.CREDIT_CARD.equals(paymentInfo.getType())){
+                                authorizeNetPaymentInfo = paymentInfo;
+                            }
+                        }
+        
+                        PaymentResponseItem paymentResponseItem = checkoutResponse.getPaymentResponse().getResponseItems().get(authorizeNetPaymentInfo);
+                        if (paymentResponseItem.getTransactionSuccess()){
+                            if (LOG.isDebugEnabled()) {
+                                LOG.debug("Transaction success for order " + checkoutResponse.getOrder().getOrderNumber());
+                                LOG.debug("Response for Authorize.net to relay to client: ");
+                                LOG.debug(authorizeNetCheckoutService.buildRelayResponse(authorizeNetConfirmUrl + "/" + checkoutResponse.getOrder().getOrderNumber()));
+                            }
+                            return authorizeNetCheckoutService.buildRelayResponse(authorizeNetConfirmUrl + "/" + checkoutResponse.getOrder().getOrderNumber());
+                        }
+                        
+                    } catch (CheckoutException e) {
+                        if (LOG.isErrorEnabled()) {
+                            LOG.error("Checkout Exception occurred processing Authorize.net relay response (params: [" + requestParamToString(request) + "])" + e);
+                        }
+                    }
+                } else {
+                    //has this order actually already been submitted and payment already calculated?
+                    Long orderId = Long.parseLong(request.getParameter(AuthorizeNetCheckoutServiceImpl.BLC_OID));
+                    order = orderService.findOrderById(orderId);
+                    //TODO: this status not always a guarantee; shore up assumptions here
+                    if (order.getStatus().equals(OrderStatus.SUBMITTED)) {
+                        return authorizeNetCheckoutService.buildRelayResponse(authorizeNetConfirmUrl + "/" + order.getOrderNumber());
+                    }
+                    
+                    //if not, there was an error and the order just straight up couldn't be determined
+                    if (LOG.isFatalEnabled()) {
+                        LOG.fatal("The order could not be determined from the Authorize.net relay response (params: [" + requestParamToString(request) + "]). NOTE: The transaction may have completed successfully. Check your application keys and hash.");
+                        throw new BroadleafAuthorizeNetException("Fatal Error has occured with in BroadleafAuthorizeNet");
+                    }
+                }
+                return authorizeNetCheckoutService.buildRelayResponse(authorizeNetErrorUrl);
+    	    } finally {
+    	        //after everything has completed, remove the lock from the map because now other requests can inspect
+    	        //it
+    	        removeLock(request.getParameter(AuthorizeNetCheckoutServiceImpl.BLC_OID));
+    	    }
+    	}
     }
-
+    
+    /**
+     * Get an object to lock on for the given order id
+     * 
+     * @param orderId
+     * @return
+     */
+    protected Object getLock(String orderId) {
+        lockMap.putIfAbsent(orderId, new Object());
+        return lockMap.get(orderId);
+    }
+    
+    /**
+     * Done with processing the given orderId, remove the lock from the map
+     * 
+     * @param orderId
+     */
+    protected void removeLock(String orderId) {
+        lockMap.remove(orderId);
+    }
 
     protected String requestParamToString(HttpServletRequest request) {
         StringBuffer requestMap = new StringBuffer();


### PR DESCRIPTION
**BLC-authnet version:** 2.0.3-SNAPSHOT
**BLC core version:** 2.0.8-SNAPSHOT

This problem occurs when a user hits the submit button twice in quick succession. Both requests go straight to Authorize.net and Authorize.net then hits back to the Broadleaf process URL twice. In this example, the first submit was approved but the second request was (correctly denied). Authorize.net forwards the approved response to Broadleaf, but also forwards a denied request. Because of this, even though the Broadleaf controller that receives the authorize.net request had already submitted the order from the first request, the Broadleaf controller also processes the _second_ request thus changing the order back to IN_PROCESS and returning the error response back to Authorize.net.

At the end of this, Authorize.net would have successfully charged the user's credit card once but the final result for the user is that they are left back on the checkout page with a message that there was a problem processing their credit card. If they they resubmit the same order (which, in this state, is a "valid" action for them to perform), their credit card will be charged a second time.

@bpolster I have attached a working copy of a fix here based on our discussion earlier. Wanted to see if I'm on the right track. This feels a bit like overkill but I think this fixes the problem of 2 requests attempting to operate on the same order as once. The desired result here is that the first Authorize.net request (in the above example) completes the order while the 2nd request (which is for the same order ID) blocks. Then, after the 1st request is finished, the 2nd request is allowed to continue, sees that the order has been submitted, and then simply returns the success response back to Authorize.net.
