### PR TITLE
Added null check to prevent NPE from occurring after a failed transaction attempt with Authorize.NET

### DIFF
--- a/src/main/java/org/broadleafcommerce/payment/service/gateway/AuthorizeNetTransactionServiceImpl.java
+++ b/src/main/java/org/broadleafcommerce/payment/service/gateway/AuthorizeNetTransactionServiceImpl.java
@@ -181,7 +181,9 @@ public class AuthorizeNetTransactionServiceImpl implements PaymentGatewayTransac
 
             responseDTO.paymentTransactionType(paymentTransactionType);
             responseDTO.rawResponse(result.getTarget().toNVPString());
-            responseDTO.amount(new Money(result.getTarget().getResponseField(ResponseField.AMOUNT)));
+            if (result.getTarget().getResponseField(ResponseField.AMOUNT) != null) {
+                responseDTO.amount(new Money(result.getTarget().getResponseField(ResponseField.AMOUNT)));
+            }
             responseDTO.orderId(result.getTarget().getMerchantDefinedField(MessageConstants.BLC_OID));
             responseDTO.responseMap(MessageConstants.TRANSACTION_TIME, SystemTime.asDate().toString());
             responseDTO.responseMap(ResponseField.RESPONSE_CODE.getFieldName(), "" + result.getResponseCode().getCode());


### PR DESCRIPTION
We were attempting to create new money with AMOUNT, which was not added to the result after an error occurred within Authorize.NET.  

Fixes #8 