### PR TITLE
Remove unnecessary "produces" attribute when processing requests from Authorize.net

### DIFF
--- a/src/main/java/org/broadleafcommerce/vendor/authorizenet/web/controller/BroadleafAuthorizeNetController.java
+++ b/src/main/java/org/broadleafcommerce/vendor/authorizenet/web/controller/BroadleafAuthorizeNetController.java
@@ -141,7 +141,7 @@ public class BroadleafAuthorizeNetController extends PaymentGatewayAbstractContr
      * @param model
      * @return
      */
-    @RequestMapping(value = "/process", method = RequestMethod.POST, produces = "text/html")
+    @RequestMapping(value = "/process", method = RequestMethod.POST)
     public @ResponseBody String process(HttpServletRequest request,
             HttpServletResponse response,
             RedirectAttributes redirectAttributes,


### PR DESCRIPTION
Fixes BroadleafCommerce/QA#998

On some implementations this causes Spring MVC to not actually map to the `/process` method.