### PR TITLE
Set X_TEST_REQUEST using "gateway.authorizenet.xTestRequest"  property

### DIFF
--- a/src/main/java/org/broadleafcommerce/payment/service/gateway/AuthorizeNetTransactionServiceImpl.java
+++ b/src/main/java/org/broadleafcommerce/payment/service/gateway/AuthorizeNetTransactionServiceImpl.java
@@ -151,6 +151,7 @@ public class AuthorizeNetTransactionServiceImpl implements PaymentGatewayTransac
             responseDTO.paymentTransactionType(paymentTransactionType);
         } else {
             Transaction transaction = merchant.createAIMTransaction(transactionType, new BigDecimal(paymentRequestDTO.getTransactionTotal()));
+            transaction.getRequestMap().put(AuthNetField.X_TEST_REQUEST.getFieldName(), configuration.getXTestRequest());
             transaction.setMerchantDefinedField(MessageConstants.BLC_OID, paymentRequestDTO.getOrderId());
             for (Entry<String, Object> field : paymentRequestDTO.getAdditionalFields().entrySet()) {
                 if (field.getValue() != null) {


### PR DESCRIPTION
- Addresses BroadleafCommerce/QA#2098

Set X_TEST_REQUEST using "gateway.authorizenet.xTestRequest"  property.

Use the PaymentGatewayTestHarness to test. 
**NOTE:** in the PaymentGatewayTestHarness `pom.xml`, make sure to point to right `autorizenet.verson` 
```xml
        <blc.authorizenet.version>2.5.2-SNAPSHOT</blc.authorizenet.version>
``xml

