### PR TITLE
Resolve environment specific url for Accept.js

### DIFF
--- a/docs/Authorize.net-Environment-Setup.md
+++ b/docs/Authorize.net-Environment-Setup.md
@@ -49,7 +49,7 @@ You will need to enter the following key/value pairs in the appropriate location
 ### common.properties
     gateway.authorizenet.transactionVersion=3.1
     gateway.authorizenet.sandbox=true
-    gateway.authorizenet.accecptJsUrl=https://jstest.authorize.net/v1/Accept.js
+    gateway.authorizenet.acceptJsUrl=https://jstest.authorize.net/v1/Accept.js
 
 ### local.properties, development.properties, integrationdev.properties, integrationqa.properties
     gateway.authorizenet.loginId=?
@@ -72,6 +72,6 @@ You will need to enter the following key/value pairs in the appropriate location
     gateway.authorizenet.merchantMd5Key=?   
     gateway.authorizenet.serverUrl=https://secure2.authorize.net/gateway/transact.dll
     gateway.authorizenet.sandbox=false
-    gateway.authorizenet.accecptJsUrl=https://js.authorize.net/v1/Accept.js
+    gateway.authorizenet.acceptJsUrl=https://js.authorize.net/v1/Accept.js
 
 Now that you have your environment set up, let's begin setting up the [[Authorize.net Quick Start]].

--- a/docs/Authorize.net-Environment-Setup.md
+++ b/docs/Authorize.net-Environment-Setup.md
@@ -49,6 +49,7 @@ You will need to enter the following key/value pairs in the appropriate location
 ### common.properties
     gateway.authorizenet.transactionVersion=3.1
     gateway.authorizenet.sandbox=true
+    gateway.authorizenet.accecptJsUrl=https://jstest.authorize.net/v1/Accept.js
 
 ### local.properties, development.properties, integrationdev.properties, integrationqa.properties
     gateway.authorizenet.loginId=?
@@ -71,5 +72,6 @@ You will need to enter the following key/value pairs in the appropriate location
     gateway.authorizenet.merchantMd5Key=?   
     gateway.authorizenet.serverUrl=https://secure2.authorize.net/gateway/transact.dll
     gateway.authorizenet.sandbox=false
+    gateway.authorizenet.accecptJsUrl=https://js.authorize.net/v1/Accept.js
 
 Now that you have your environment set up, let's begin setting up the [[Authorize.net Quick Start]].

--- a/docs/Authorize.net-Quick-Start.md
+++ b/docs/Authorize.net-Quick-Start.md
@@ -19,7 +19,7 @@ These instructions assume integration with the default Heat Clinic Demo Site pro
     <script type="text/javascript" src="https://jstest.authorize.net/v1/Accept.js" charset="utf-8"></script>
 <!-- For Production, use: -->
     <script type="text/javascript" src="https://js.authorize.net/v1/Accept.js" charset="utf-8"></script>
-<!-- To resolve the url from the gateway.authorizenet.accecptJsUrl system variable, use: -->
+<!-- To resolve the url from the gateway.authorizenet.acceptJsUrl system variable, use: -->
     <script type="text/javascript" th:src="${#authorizenet.getAcceptJsUrl()}" charset="utf-8"></script>
 ```
 

--- a/docs/Authorize.net-Quick-Start.md
+++ b/docs/Authorize.net-Quick-Start.md
@@ -14,7 +14,13 @@ These instructions assume integration with the default Heat Clinic Demo Site pro
 1. Make sure the Authorize.net JS library is loaded on your checkout page:
 
 ```html
-<script src="https://jstest.authorize.net/v1/Accept.js"></script>
+
+<!-- For Sandbox/Testing, use: -->
+    <script type="text/javascript" src="https://jstest.authorize.net/v1/Accept.js" charset="utf-8"></script>
+<!-- For Production, use: -->
+    <script type="text/javascript" src="https://js.authorize.net/v1/Accept.js" charset="utf-8"></script>
+<!-- To resolve the url from the gateway.authorizenet.accecptJsUrl system variable, use: -->
+    <script type="text/javascript" th:src="${#authorizenet.getAcceptJsUrl()}" charset="utf-8"></script>
 ```
 
 2. Modify the Payment Form on your checkout page to look something like:

--- a/src/main/java/org/broadleafcommerce/payment/service/gateway/AuthorizeNetConfiguration.java
+++ b/src/main/java/org/broadleafcommerce/payment/service/gateway/AuthorizeNetConfiguration.java
@@ -130,4 +130,5 @@ public interface AuthorizeNetConfiguration extends PaymentGatewayConfiguration {
     
     public Boolean isSandbox();
 
+    public String getAcceptJsUrl();
 }

--- a/src/main/java/org/broadleafcommerce/payment/service/gateway/AuthorizeNetConfigurationImpl.java
+++ b/src/main/java/org/broadleafcommerce/payment/service/gateway/AuthorizeNetConfigurationImpl.java
@@ -223,5 +223,10 @@ public class AuthorizeNetConfigurationImpl extends AbstractPaymentGatewayConfigu
     public Boolean isSandbox() {
         return propertiesService.resolveBooleanSystemProperty("gateway.authorizenet.sandbox", true);
     }
+
+    @Override
+    public String getAcceptJsUrl() {
+        return propertiesService.resolveSystemProperty("gateway.authorizenet.accecptJsUrl");
+    }
     
 }

--- a/src/main/java/org/broadleafcommerce/payment/service/gateway/AuthorizeNetConfigurationImpl.java
+++ b/src/main/java/org/broadleafcommerce/payment/service/gateway/AuthorizeNetConfigurationImpl.java
@@ -226,7 +226,7 @@ public class AuthorizeNetConfigurationImpl extends AbstractPaymentGatewayConfigu
 
     @Override
     public String getAcceptJsUrl() {
-        return propertiesService.resolveSystemProperty("gateway.authorizenet.accecptJsUrl");
+        return propertiesService.resolveSystemProperty("gateway.authorizenet.acceptJsUrl", "https://js.authorize.net/v1/Accept.js");
     }
     
 }

--- a/src/main/java/org/broadleafcommerce/vendor/authorizenet/web/expression/AuthorizeNetVariableExpression.java
+++ b/src/main/java/org/broadleafcommerce/vendor/authorizenet/web/expression/AuthorizeNetVariableExpression.java
@@ -60,5 +60,9 @@ public class AuthorizeNetVariableExpression implements BroadleafVariableExpressi
         return configuration.getLoginId();
     }
 
+    public String getAcceptJsUrl() {
+        return configuration.getAcceptJsUrl();
+    }
+
 }
 


### PR DESCRIPTION
Added processor and configuration methods to resolve `gateway.authorizenet.accecptJsUrl` from system properties for use when loading Accept.js on the checkout page. Also updated the docs to note that the url should be different in development and production