### PR TITLE
Fixed is a bug that is failing a rollback on a purchase path failure,…

### DIFF
--- a/src/main/java/org/broadleafcommerce/payment/service/gateway/AuthorizeNetTransactionServiceImpl.java
+++ b/src/main/java/org/broadleafcommerce/payment/service/gateway/AuthorizeNetTransactionServiceImpl.java
@@ -170,19 +170,19 @@ public class AuthorizeNetTransactionServiceImpl extends AbstractPaymentGatewayTr
                 responseDTO.responseMap(ResponseField.RESPONSE_REASON_CODE.getFieldName(), "" + response.getTransactionResponse().getRawResponseCode());
                 responseDTO.responseMap(ResponseField.AMOUNT.getFieldName(), paymentRequestDTO.getTransactionTotal().toString());
                 responseDTO.responseMap(ResponseField.AUTHORIZATION_CODE.getFieldName(), response.getTransactionResponse().getAuthCode());
-                responseDTO.responseMap(ResponseField.ACCOUNT_NUMBER.getFieldName(), response.getTransactionResponse().getAccountNumber())
-                           .responseMap(AuthNetField.X_INVOICE_NUM.getFieldName(), transactionVoid.getOrder().getInvoiceNumber())
-                           .responseMap(AuthNetField.X_LOGIN.getFieldName(), configuration.getLoginId())
-                           .responseMap(AuthNetField.X_VERSION_FIELD.getFieldName(), configuration.getTransactionVersion())
-                           .responseMap(AuthNetField.X_METHOD.getFieldName(), "CC")
-                           .responseMap(AuthNetField.X_TYPE.getFieldName(), transactionType.getValue())
-                           .responseMap(AuthNetField.X_AMOUNT.getFieldName(), paymentRequestDTO.getTransactionTotal())
-                           .responseMap(AuthNetField.X_TEST_REQUEST.getFieldName(), configuration.getXTestRequest())
-                           .responseMap(AuthNetField.X_CUST_ID.getFieldName(), paymentRequestDTO.getCustomer().getCustomerId())
-                           .responseMap(AuthNetField.X_TRANS_ID.getFieldName(), response.getTransactionResponse().getTransId())
-                           .responseMap(MessageConstants.BLC_CID, paymentRequestDTO.getCustomer().getCustomerId())
-                           .responseMap(MessageConstants.BLC_OID, paymentRequestDTO.getOrderId())
-                           .responseMap(MessageConstants.AUTHORIZENET_SERVER_URL, configuration.getServerUrl());
+                responseDTO.responseMap(ResponseField.ACCOUNT_NUMBER.getFieldName(), response.getTransactionResponse().getAccountNumber());
+                responseDTO.responseMap(AuthNetField.X_INVOICE_NUM.getFieldName(), (String)paymentRequestDTO.getAdditionalFields().get("x_invoice_num"));
+                responseDTO.responseMap(AuthNetField.X_LOGIN.getFieldName(), configuration.getLoginId());
+                responseDTO.responseMap(AuthNetField.X_VERSION_FIELD.getFieldName(), configuration.getTransactionVersion());
+                responseDTO.responseMap(AuthNetField.X_METHOD.getFieldName(), "CC");
+                responseDTO.responseMap(AuthNetField.X_TYPE.getFieldName(), transactionType.getValue());
+                responseDTO.responseMap(AuthNetField.X_AMOUNT.getFieldName(), paymentRequestDTO.getTransactionTotal());
+                responseDTO.responseMap(AuthNetField.X_TEST_REQUEST.getFieldName(), configuration.getXTestRequest());
+                responseDTO.responseMap(AuthNetField.X_CUST_ID.getFieldName(), paymentRequestDTO.getCustomer().getCustomerId());
+                responseDTO.responseMap(AuthNetField.X_TRANS_ID.getFieldName(), response.getTransactionResponse().getTransId());
+                responseDTO.responseMap(MessageConstants.BLC_CID, paymentRequestDTO.getCustomer().getCustomerId());
+                responseDTO.responseMap(MessageConstants.BLC_OID, paymentRequestDTO.getOrderId());
+                responseDTO.responseMap(MessageConstants.AUTHORIZENET_SERVER_URL, configuration.getServerUrl());
                 
                 if(paymentRequestDTO.billToPopulated()) {
                     responseDTO.responseMap(AuthNetField.X_FIRST_NAME.getFieldName(), paymentRequestDTO.getBillTo().getAddressFirstName())


### PR DESCRIPTION
… specifically an 'invoice number' was trying to be retrieved from a null order

@phillipuniverse Not sure whether a ticket should be created but I thought I'd get this PR over to you for review as I will be unavailable

# Bug Details
It seems it is attempting to do a rollback but the rollback is failing in `AuthorizeNetTransactionServiceImpl.common()`. In this method it’s building a `TransactionRequestType`, it sets `transactionType`, `refTransId`, `customer`, `payment` and `amount`. Later on it builds a `responseDTO` with a field ‘invoice number’ and it’s trying to get this value from an orderType referenced in `TransactionRequestType`. Between creation, setting those five attribs and *this* line an `OrderType` is never associated with this `TransactionRequestType`. During debugging I set this `TransactionRequestType.orderType` to a newly instantiated OrderType and lo and behold - success, and a CreditAccountEvent of type ROLLBACK was created for the CA.

# Fix Details
The invoice number in the responseMap is now populate with an available 'invoice number' in the additional fields of the payment request. When creating the responseMap the code exhibited a mixture of single statements adding fields to the responseMap, i.e.:

```
responseDTO.responseMap(...);
responseDTO.responseMap(...);
responseDTO.responseMap(...);
```

 as well as a chained construction statement:

```
responseDTO.responseMap(...)
                      .responseMap()
                      .responseMap()
```

This has been cleaned up so there is no chaining.